### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,6 +296,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <a href="https://patreon.com/user?u=93873537&utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink" target="_blank" class="ga-link" data-ga-event="patreon_footer_click">Patreon</a> |
         <!--  <a href="https://t.me/yourtelegram" target="_blank" class="ga-link" data-ga-event="telegram_click">Telegram</a> -->
       </div>
+        <div class="policy-links mb-3">
+          <a href="/privacy/">Політика конфіденційності</a> |
+          <a href="/terms/">Умови використання</a>
+        </div>
       <p data-i18n="footerText">© 2025 DBN Assistant. Всі права захищені.</p>
     </div>
   </footer>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Політика конфіденційності - DBN Assistant</title>
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+</head>
+<body>
+  <nav class="navbar navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="/">DBN Assistant</a>
+    </div>
+  </nav>
+  <main class="container py-5">
+    <h1>Політика конфіденційності</h1>
+
+    <h2>1.1 Збір інформації</h2>
+    <p>Ми можемо збирати наступні типи інформації:</p>
+    <ul>
+      <li><strong>Персональні дані</strong> – ім’я, адреса електронної пошти, інформація про оплату, яку ви добровільно надаєте нам, реєструючись або здійснюючи покупку.</li>
+      <li><strong>Технічні дані</strong> – IP-адреса, тип браузера, файл cookies, дані про пристрій та час відвідування.</li>
+    </ul>
+
+    <h2>1.2 Використання інформації</h2>
+    <p>Ми використовуємо зібрані дані для:</p>
+    <ul>
+      <li>надання послуг (реєстрація, обробка платежів, підтримка);</li>
+      <li>покращення якості сервісу та персоналізації досвіду;</li>
+      <li>надсилання сповіщень та інформаційних листів (за вашою згодою).</li>
+    </ul>
+
+    <h2>1.3 Передача даних третім сторонам</h2>
+    <p>Ми не продаємо та не розповсюджуємо вашу особисту інформацію третім сторонам, за винятком:</p>
+    <ul>
+      <li>служб, які допомагають обробляти платежі або забезпечувати функціонал сайту (вони зобов’язані дотримуватись конфіденційності);</li>
+      <li>випадків, коли передачу даних вимагає закон або судовий орган.</li>
+    </ul>
+
+    <h2>1.4 Cookies</h2>
+    <p>Ми використовуємо cookies для аналізу відвідувань і полегшення використання сайту. Ви можете контролювати або вимикати cookies у налаштуваннях вашого браузера.</p>
+
+    <h2>1.5 Безпека</h2>
+    <p>Ми вживаємо відповідних заходів безпеки для захисту ваших даних. Однак неможливо гарантувати абсолютну безпеку під час передачі або зберігання інформації.</p>
+
+    <h2>1.6 Ваші права</h2>
+    <p>Ви маєте право:</p>
+    <ul>
+      <li>отримати доступ до своїх персональних даних;</li>
+      <li>вимагати їх корекції або видалення;</li>
+      <li>відкликати згоду на обробку інформації.</li>
+    </ul>
+    <p>Для реалізації прав звертайтесь за адресою: <a href="mailto:contact@ваш-домен.example">contact@ваш-домен.example</a>.</p>
+
+    <h2>1.7 Зміни до політики</h2>
+    <p>Ми можемо час від часу оновлювати цю Політику. Нову версію буде розміщено на цій сторінці з оновленою датою.</p>
+
+    <p><strong>Дата набуття чинності:</strong> 01.01.2025</p>
+    <p><strong>Контактна інформація:</strong> <a href="mailto:contact@ваш-домен.example">contact@ваш-домен.example</a></p>
+  </main>
+  <footer>
+    <div class="container text-center">
+      <div class="social-links mb-3">
+        <a href="https://www.facebook.com/iv.mybox" target="_blank">Facebook</a> |
+        <a href="https://patreon.com/user?u=93873537&utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink" target="_blank">Patreon</a>
+      </div>
+      <div class="policy-links mb-3">
+        <a href="/privacy/">Політика конфіденційності</a> |
+        <a href="/terms/">Умови використання</a>
+      </div>
+      <p>© 2025 DBN Assistant. Всі права захищені.</p>
+    </div>
+  </footer>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -60,4 +60,16 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://www.dbnassistant.com/privacy</loc>
+    <lastmod>2025-02-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://www.dbnassistant.com/terms</loc>
+    <lastmod>2025-02-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Умови використання - DBN Assistant</title>
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+</head>
+<body>
+  <nav class="navbar navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="/">DBN Assistant</a>
+    </div>
+  </nav>
+  <main class="container py-5">
+    <h1>Умови використання</h1>
+
+    <h2>2.1 Прийняття умов</h2>
+    <p>Використовуючи наш сайт або послуги, ви підтверджуєте, що ознайомилися і погоджуєтеся з цими Умовами використання.</p>
+
+    <h2>2.2 Вміст сайту та інтелектуальна власність</h2>
+    <p>Увесь текст, зображення, логотипи, елементи дизайну та інший контент належать нам або використовуються з дозволу. Заборонено копіювати чи розповсюджувати матеріали без нашої письмової згоди.</p>
+
+    <h2>2.3 Користувацький контент</h2>
+    <p>Ви несете відповідальність за контент, який публікуєте або завантажуєте. Забороняється розміщувати незаконні матеріали, контент, що порушує авторські права чи права інших осіб, або є образливим.</p>
+
+    <h2>2.4 Обмеження відповідальності</h2>
+    <p>Ми не гарантуємо безперебійність роботи сайту та не несемо відповідальності за будь-які прямі чи непрямі збитки, що виникли внаслідок використання сайту або неможливості його використання.</p>
+
+    <h2>2.5 Посилання на сторонні ресурси</h2>
+    <p>Наш сайт може містити посилання на сторонні веб-сайти. Ми не контролюємо їхній зміст і не несемо відповідальності за використання ваших даних на цих сайтах.</p>
+
+    <h2>2.6 Зміни в Умовах</h2>
+    <p>Ми залишаємо за собою право змінювати ці Умови в будь-який час. Оновлення публікуються на цій сторінці з новою датою.</p>
+
+    <h2>2.7 Припинення доступу</h2>
+    <p>Ми можемо припинити або призупинити ваш доступ до сайту, якщо ви порушуєте Умови або наші політики.</p>
+
+    <p><strong>Дата набуття чинності:</strong> 01.01.2025</p>
+    <p><strong>Контактна інформація:</strong> <a href="mailto:contact@ваш-домен.example">contact@ваш-домен.example</a></p>
+  </main>
+  <footer>
+    <div class="container text-center">
+      <div class="social-links mb-3">
+        <a href="https://www.facebook.com/iv.mybox" target="_blank">Facebook</a> |
+        <a href="https://patreon.com/user?u=93873537&utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink" target="_blank">Patreon</a>
+      </div>
+      <div class="policy-links mb-3">
+        <a href="/privacy/">Політика конфіденційності</a> |
+        <a href="/terms/">Умови використання</a>
+      </div>
+      <p>© 2025 DBN Assistant. Всі права захищені.</p>
+    </div>
+  </footer>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create standalone Privacy Policy and Terms of Service pages
- link policy pages in footer and sitemap for easier discovery

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b57b579b68832fa64f4649378423a9